### PR TITLE
Add missing table to migration reversal

### DIFF
--- a/lib/generators/motor/templates/install.rb
+++ b/lib/generators/motor/templates/install.rb
@@ -186,5 +186,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
     drop_table :motor_configs
     drop_table :motor_queries
     drop_table :motor_dashboards
+    drop_table :motor_api_configs
   end
 end


### PR DESCRIPTION
This PR adds a missing table drop when reversing the installed migration. I kept getting errors when running `bin/rails db:migrate:redo`.