### PR TITLE
FIX: adopt for nil in nested params

### DIFF
--- a/app/controllers/motor/data_controller.rb
+++ b/app/controllers/motor/data_controller.rb
@@ -64,7 +64,7 @@ module Motor
 
     def execute
       resource_preferences = Motor::Resource.find_by(name: @resource.class.name.underscore).preferences
-      resource_action = resource_preferences[:actions].find { |a| a[:preferences][:method_name] == params[:method] }
+      resource_action = resource_preferences[:actions].find { |a| a.dig(:preferences, :method_name) == params[:method] }
 
       authorize!(resource_action[:name].to_sym, @resource)
 


### PR DESCRIPTION
When I create custom method and use it 

I got an exception

```
Started PUT "/admin/api/data/notificator/0184e8f1-d555-7016-81eb-8b50d632b55d/import_metadata" for 127.0.0.1 at 2022-12-06 23:28:00 +0300
Processing by Motor::DataController#execute as HTML
  Parameters: {"resource"=>"notificator", "resource_id"=>"0184e8f1-d555-7016-81eb-8b50d632b55d", "method"=>"import_metadata", "data"=>{}}
  Motor::Resource Maximum (0.8ms)  SELECT MAX("motor_resources"."updated_at") FROM "motor_resources"
  Word Load (0.9ms)  SELECT "notificator".* FROM "notificator" WHERE "notificator"."id" = $1 LIMIT $2  [["id", "0184e8f1-d555-7016-81eb-8b50d632b55d"], ["LIMIT", 1]]
  Motor::Resource Load (0.7ms)  SELECT "motor_resources".* FROM "motor_resources" WHERE "motor_resources"."name" = $1 LIMIT $2  [["name", "notificator"], ["LIMIT", 1]]
undefined method `[]' for nil:NilClass

      resource_action = resource_preferences[:actions].find { |a| a[:preferences][:method_name] == params[:method] }
                                                                                 ^^^^^^^^^^^^^^
/home/player/.rvm/gems/ruby-3.1.2@project/gems/motor-admin-0.4.2/app/controllers/motor/data_controller.rb:67:in `block in execute'
/home/player/.rvm/gems/ruby-3.1.2@project/gems/motor-admin-0.4.2/app/controllers/motor/data_controller.rb:67:in `each'
/home/player/.rvm/gems/ruby-3.1.2@project/gems/motor-admin-0.4.2/app/controllers/motor/data_controller.rb:67:in `find'
/home/player/.rvm/gems/ruby-3.1.2@project/gems/motor-admin-0.4.2/app/controllers/motor/data_controller.rb:67:in `execute'/home/player/.rvm/gems/ruby-3.1.2@project/gems/actionpack-7.0.4/lib/action_controller/metal/basic_implicit_render.rb:6:in
....
```



