### PR TITLE
Active Storage Direct Upload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    motor-admin (0.4.21)
+    motor-admin (0.4.22)
       ar_lazy_preload (~> 1.0)
       audited (~> 5.0)
       cancancan (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ rails motor:install && rake db:migrate
 * [Dashboards](#dashboards)
 * [Email alerts](#email-alerts)
 * [Authorization](#authorization)
+* [Active Storage](#active-storage)
 * [Intelligence search](#intelligence-search)
 * [I18n](#i18n)
 * [Optimized for mobile](#optimized-for-mobile)
@@ -133,6 +134,16 @@ Intelligence search can be opened via the top right corner button or using <kbd>
 ### Authorization
 
 Motor Admin allows to set row-level and column-level permissions via [cancan](https://github.com/CanCanCommunity/cancancan) gem. Admin UI permissions should be defined in `app/models/motor/ability.rb` file in `Motor::Ability` class. See [Motor Admin guide](https://github.com/motor-admin/motor-admin-rails/blob/master/guides/defining_permissions.md) and [CanCan documentation](https://github.com/CanCanCommunity/cancancan/blob/develop/docs/Defining-Abilities.md) to learn how to define user permissions.
+
+### Active Storage
+
+Motor Admin is configured by default to perform uploads to the provider you configured in your `storage.yml` file for Active Storage. If you are using large uploads within Motor Admin you will need to enable direct uploads by setting the following ENV variable. 
+
+```sh
+MOTOR_ACTIVE_STORAGE_DIRECT_UPLOADS_ENABLED=true
+```
+
+_Note: At the moment, this will enable direct uploads globally_
 
 ### I18n
 

--- a/lib/motor/configs/build_ui_app_tag.rb
+++ b/lib/motor/configs/build_ui_app_tag.rb
@@ -34,6 +34,7 @@ module Motor
       end
 
       # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       # @return [Hash]
       def build_data(cache_keys = {}, current_user = nil, current_ability = nil)
         configs_cache_key = cache_keys[:configs]
@@ -60,6 +61,7 @@ module Motor
           forms: forms_data_hash(build_cache_key(cache_keys, :forms, current_user, current_ability), current_ability) }
       end
       # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
       def i18n_data
         I18n.t('motor', default: I18n.t('motor', locale: :en))

--- a/lib/motor/configs/build_ui_app_tag.rb
+++ b/lib/motor/configs/build_ui_app_tag.rb
@@ -46,6 +46,7 @@ module Motor
           base_path: Motor::Admin.routes.url_helpers.motor_path,
           cable_path: Motor::Admin.routes.url_helpers.try(:motor_cable_path),
           admin_settings_path: Rails.application.routes.url_helpers.try(:admin_settings_general_path),
+          active_storage_direct_uploads_enabled: ENV['MOTOR_ACTIVE_STORAGE_DIRECT_UPLOADS_ENABLED'] === 'true',
           schema: Motor::BuildSchema.call(cache_keys, current_ability),
           header_links: header_links_data_hash(current_user, current_ability, configs_cache_key),
           homepage_layout: homepage_layout_data_hash(configs_cache_key),

--- a/lib/motor/configs/build_ui_app_tag.rb
+++ b/lib/motor/configs/build_ui_app_tag.rb
@@ -46,7 +46,7 @@ module Motor
           base_path: Motor::Admin.routes.url_helpers.motor_path,
           cable_path: Motor::Admin.routes.url_helpers.try(:motor_cable_path),
           admin_settings_path: Rails.application.routes.url_helpers.try(:admin_settings_general_path),
-          active_storage_direct_uploads_enabled: ENV['MOTOR_ACTIVE_STORAGE_DIRECT_UPLOADS_ENABLED'] === 'true',
+          active_storage_direct_uploads_enabled: ENV['MOTOR_ACTIVE_STORAGE_DIRECT_UPLOADS_ENABLED'].present?,
           schema: Motor::BuildSchema.call(cache_keys, current_ability),
           header_links: header_links_data_hash(current_user, current_ability, configs_cache_key),
           homepage_layout: homepage_layout_data_hash(configs_cache_key),

--- a/lib/motor/version.rb
+++ b/lib/motor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motor
-  VERSION = '0.4.21'
+  VERSION = '0.4.22'
 end

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/actioncable": "^6.1.4-1",
     "@rails/actiontext": "^6.0.5",
+    "@rails/activestorage": "^7.0.8",
     "@tabler/icons": "^1.68.0",
     "axios": "^0.27.2",
     "bootstrap": "^5.1.3",

--- a/ui/src/data_forms/components/input.vue
+++ b/ui/src/data_forms/components/input.vue
@@ -102,10 +102,12 @@
 </template>
 
 <script>
+import { DirectUpload } from '@rails/activestorage'
 import Emitter from 'view3/src/mixins/emitter'
 import ResourceSelect from 'data_resources/components/select'
 import QueryValueSelect from 'queries/components/value_select'
 import VueTrix from 'utils/components/vue_trix'
+import { isActiveStorageDirectUploadsEnabled } from 'utils/scripts/configs'
 import { titleize } from 'utils/scripts/string'
 import OptionsInput from 'utils/components/options_input'
 import ColorPicker from 'view3/src/components/color-picker'
@@ -244,6 +246,14 @@ export default {
                 resolve(location.origin + result.data.data.path)
               }).catch((error) => {
                 reject(error)
+              })
+            } else if (isActiveStorageDirectUploadsEnabled) {
+              new DirectUpload(file, '/rails/active_storage/direct_uploads').create((error, blob) => {
+                if (error) {
+                  reject(error)
+                } else {
+                  resolve(blob.signed_id)
+                }
               })
             } else {
               resolve({ filename: file.name, io: reader.result })

--- a/ui/src/utils/scripts/configs.js
+++ b/ui/src/utils/scripts/configs.js
@@ -4,6 +4,7 @@ const basePath = appNode.getAttribute('data-base-path')
 const cablePath = appNode.getAttribute('data-cable-path')
 const adminSettingsPath = appNode.getAttribute('data-admin-settings-path')
 const version = appNode.getAttribute('data-version')
+const isActiveStorageDirectUploadsEnabled = JSON.parse(appNode.getAttribute('data-active-storage-direct-uploads-enabled'))
 const canCanRules = JSON.parse(appNode.getAttribute('data-current-rules'))
 const databaseNames = JSON.parse(appNode.getAttribute('data-databases'))
 const i18nDict = JSON.parse(appNode.getAttribute('data-i18n'))
@@ -17,5 +18,6 @@ export {
   canCanRules,
   i18nDict,
   isStandalone,
+  isActiveStorageDirectUploadsEnabled,
   databaseNames
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1152,6 +1152,13 @@
   dependencies:
     spark-md5 "^3.0.0"
 
+"@rails/activestorage@^7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-7.0.8.tgz#7ea8a656b5621e0dc57f51e3ad2f06c3af30d3ea"
+  integrity sha512-CxPyCxTV0HIaZP8qqH11tkESNl8TrQsIAesAgeOXDOl0BkaN6nC0/Mq2/0ngezBu9CZbFzfHtP2g6Yl8BWkV8g==
+  dependencies:
+    spark-md5 "^3.0.1"
+
 "@tabler/icons@^1.68.0":
   version "1.68.0"
   resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-1.68.0.tgz#047bd88966cc24ef957b3c429a13bb82cca95561"
@@ -6300,7 +6307,7 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-spark-md5@^3.0.0:
+spark-md5@^3.0.0, spark-md5@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==


### PR DESCRIPTION
## Description

This PR adds [Direct Uploads](https://edgeguides.rubyonrails.org/active_storage_overview.html#direct-uploads) functionality to Motor Admin. It allows a user to opt-in to enabled it globally throughout their Admin interface. It will perform small and large uploads using the direct upload behavior.

To configure your Active Storage provider correctly to use Direct Uploads, please see the Rails documentation on setting up the correct CORS policies. 


Adds environment variable `MOTOR_ACTIVE_STORAGE_DIRECT_UPLOADS_ENABLED` that controls global direct upload functionality.