### PR TITLE
chore: use `Rails.application.credentials` instead of `secrets`

### DIFF
--- a/app/controllers/motor/auth_tokens_controller.rb
+++ b/app/controllers/motor/auth_tokens_controller.rb
@@ -28,7 +28,7 @@ module Motor
 
     def respond_with_generic_jwt
       payload = { uid: current_user.id, exp: GENERIC_TOKEN_TTL.from_now.to_i }
-      token = JWT.encode(payload, Rails.application.secrets.secret_key_base)
+      token = JWT.encode(payload, Rails.application.credentials.secret_key_base)
 
       render json: { token: token }
     end

--- a/app/controllers/motor/run_api_requests_controller.rb
+++ b/app/controllers/motor/run_api_requests_controller.rb
@@ -46,7 +46,7 @@ module Motor
 
       payload = { uid: current_user.id, email: current_user.email, exp: JWT_TTL.from_now.to_i }
 
-      JWT.encode(payload, Rails.application.secrets.secret_key_base)
+      JWT.encode(payload, Rails.application.credentials.secret_key_base)
     end
 
     def request_params

--- a/app/controllers/motor/run_graphql_requests_controller.rb
+++ b/app/controllers/motor/run_graphql_requests_controller.rb
@@ -38,7 +38,7 @@ module Motor
 
       payload = { uid: current_user.id, email: current_user.email, exp: JWT_TTL.from_now.to_i }
 
-      JWT.encode(payload, Rails.application.secrets.secret_key_base)
+      JWT.encode(payload, Rails.application.credentials.secret_key_base)
     end
 
     def request_params


### PR DESCRIPTION
`Rails.application.secrets` is deprecated in rails 7.1 and will be removed in rails 7.2. all we need to do, however, is use the `credentials` method:

```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2.
```