### PR TITLE
chore: use keyword argument when passing coder to `serialize` method

### DIFF
--- a/app/models/motor/api_config.rb
+++ b/app/models/motor/api_config.rb
@@ -7,11 +7,11 @@ module Motor
     attribute :preferences, default: -> { ActiveSupport::HashWithIndifferentAccess.new }
     attribute :credentials, default: -> { ActiveSupport::HashWithIndifferentAccess.new }
 
-    serialize :credentials, Motor::HashSerializer
-
     if Rails.version.to_f >= 7.1
+      serialize :credentials, coder: Motor::HashSerializer
       serialize :preferences, coder: Motor::HashSerializer
     else
+      serialize :credentials, Motor::HashSerializer
       serialize :preferences, Motor::HashSerializer
     end
 

--- a/lib/motor/version.rb
+++ b/lib/motor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motor
-  VERSION = '0.4.23'
+  VERSION = '0.4.24'
 end


### PR DESCRIPTION
in rails 7.1 using positional arguments causes a deprecation warning. so we use the `coder` kwarg as in most other cases. i think this one was missed when the others were changed.

also revved the version to prep for a new release. happy to remove it if you do releases differently :smiley: 