### PR TITLE
Gracefully handle when there are no alerts on Rails 7.1

### DIFF
--- a/lib/motor/alerts/scheduled_alerts_cache.rb
+++ b/lib/motor/alerts/scheduled_alerts_cache.rb
@@ -9,7 +9,11 @@ module Motor
 
       def all
         ActiveRecord::Base.logger.silence do
-          CACHE_STORE.fetch(Motor::Alert.all.maximum(:updated_at)) do
+          cache_key = Motor::Alert.all.maximum(:updated_at)
+
+          return [] if cache_key.nil?
+
+          CACHE_STORE.fetch(cache_key) do
             clear
 
             Motor::Alert.all.active.enabled.to_a


### PR DESCRIPTION
Rails 7.1+ does not allow a `nil` key to be passed in to `Cache#fetch` (rails/rails#48043), so now we short-circuit if the cache key is `nil`, returning an empty array.