### PR TITLE
Add support for progress bars on Active Storage Direct Uploads

### DIFF
--- a/ui/src/utils/scripts/active_storage_direct_uploader.js
+++ b/ui/src/utils/scripts/active_storage_direct_uploader.js
@@ -1,0 +1,28 @@
+import { DirectUpload } from "@rails/activestorage"
+
+export default class ActiveStorageDirectUploader {
+  constructor(file, url, options) {
+    this.upload = new DirectUpload(file, url, this)
+    this.options = options
+  }
+
+  uploadFile(file) {
+    return new Promise((resolve, reject) => {
+      this.upload.create((error, blob) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(blob);
+        }
+      })
+    });
+  }
+
+  directUploadWillStoreFileWithXHR(request) {
+    if (this.options.onProgress) {
+      request.upload.addEventListener("progress", event => {
+        this.options.onProgress(event);
+      });
+    }
+  }
+}


### PR DESCRIPTION
Active Storage Direct Upload attachments will now use a progress bar instead of the spinner to better indicate progress when uploading large files.

Non-Active Storage methods will still use the spinner as always.

I refactored the direct uploading functionality into its own utility class. This is for tidyness but also because that's the only way that the DirectUpload module allows implementing progress. See [here](https://edgeguides.rubyonrails.org/active_storage_overview.html#track-the-progress-of-the-file-upload) for more info.