### PR TITLE
Fix creation of records for Rails 7.2 version

### DIFF
--- a/config/initializers/audited.rb
+++ b/config/initializers/audited.rb
@@ -1,0 +1,5 @@
+if Rails.gem_version >= Gem::Version.new("7.2")
+  require 'audited/audit'
+
+  Audited::Audit.abstract_class = true
+end

--- a/lib/motor/resources/fetch_configured_model.rb
+++ b/lib/motor/resources/fetch_configured_model.rb
@@ -187,6 +187,7 @@ module Motor
         end
 
         klass._reflections = klass.reflections
+        klass._reflections.symbolize_keys! if Rails.gem_version >= Gem::Version.new("7.2")
 
         klass
       end


### PR DESCRIPTION
Fixes #174 

I'm not sure what's going to happen when someone is using the `audited` gem besides the audits provided by the `motor-admin` gem. Is the initializer a good place to go? Maybe a better way would be to create a generator which would be triggered during update and/or installation of the `motor-admin` gem with additional messages for end users?

Regarding the change in the `fetch_configured_model.rb` file, this one failed when using the Rails 7.2. That was because `klass.reflections` had keys which were strings, however `klass._reflections` should have symbolized keys in Rails 7.2. 

Edit:

Regarding the audited issue. Maybe event better alternative would be to configure the class as an abstract class on and off inside a transaction? That way the behaviour would be benign, the end user wouldn't have to worry about the audited issue at all.