### PR TITLE
Fix: Move wrap_io_params callback setup from concern to controllers

### DIFF
--- a/app/controllers/concerns/motor/wrap_io_params.rb
+++ b/app/controllers/concerns/motor/wrap_io_params.rb
@@ -2,12 +2,6 @@
 
 module Motor
   module WrapIoParams
-    extend ActiveSupport::Concern
-
-    included do
-      before_action :wrap_io_params, only: %i[update create]
-    end
-
     private
 
     def wrap_io_params(hash = params)

--- a/app/controllers/motor/active_storage_attachments_controller.rb
+++ b/app/controllers/motor/active_storage_attachments_controller.rb
@@ -4,6 +4,8 @@ module Motor
   class ActiveStorageAttachmentsController < ApiBaseController
     include Motor::WrapIoParams
 
+    before_action :wrap_io_params, only: :create
+
     wrap_parameters :data, except: %i[include fields]
 
     load_and_authorize_resource :attachment, class: 'ActiveStorage::Attachment', parent: false

--- a/app/controllers/motor/data_controller.rb
+++ b/app/controllers/motor/data_controller.rb
@@ -7,6 +7,8 @@ module Motor
     include Motor::WrapIoParams
     include Motor::LoadAndAuthorizeDynamicResource
 
+    before_action :wrap_io_params, only: %i[update create]
+
     def index
       @resources = Motor::ApiQuery.call(@resources, params)
 


### PR DESCRIPTION
Fixes #169 

Looks like there's a new default in Rails 7.1 when registering callbacks and setting the actions on which it'll be run. The `only` option by default raises an exception. I have extracted the callback registration from a concern to controllers. Those controllers became more explicit by that. If you which I could try to configure the engine so it could use the old defaults and not raise an exception.

More informations here: https://guides.rubyonrails.org/configuring.html#config-action-controller-raise-on-missing-callback-actions