### PR TITLE
Credentials based Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,15 @@ MOTOR_SYNC_REMOTE_URL=https://remote-app-url/ MOTOR_SYNC_API_KEY=secure-random-s
 
 ## Authentication
 
-Admin panel can be secured with 'Basic authentication' by specifying `MOTOR_AUTH_USERNAME` and `MOTOR_AUTH_PASSWORD` environment variables.
+Admin panel can be secured with 'Basic authentication' by specifying `MOTOR_AUTH_USERNAME` and `MOTOR_AUTH_PASSWORD` environment variables. Alternatively, the username and password can be added to the credentials file:
 
-Alternatively, it can be secured with [devise](https://github.com/heartcombo/devise/wiki/How-To:-Define-resource-actions-that-require-authentication-using-routes.rb) or any other authentication library used by the application:
+```yaml
+motor:
+  username: <username>
+  password: <password>
+```
+
+The admin panel can also be secured using [devise](https://github.com/heartcombo/devise/wiki/How-To:-Define-resource-actions-that-require-authentication-using-routes.rb) or any other authentication library used by the application:
 
 ```ruby
 authenticate :admin_user do

--- a/lib/motor/admin.rb
+++ b/lib/motor/admin.rb
@@ -67,16 +67,18 @@ module Motor
     end
 
     initializer 'motor.basic_auth' do
-      next if ENV['MOTOR_AUTH_PASSWORD'].blank?
+      motor_username = ENV['MOTOR_AUTH_USERNAME'].presence || Rails.application.credentials.dig(:motor, :username)
+      motor_password = ENV['MOTOR_AUTH_PASSWORD'].presence || Rails.application.credentials.dig(:motor, :password)
+      next if motor_username.blank? || motor_password.blank?
 
       config.middleware.use Rack::Auth::Basic do |username, password|
         ActiveSupport::SecurityUtils.secure_compare(
           ::Digest::SHA256.hexdigest(username),
-          ::Digest::SHA256.hexdigest(ENV['MOTOR_AUTH_USERNAME'].to_s)
+          ::Digest::SHA256.hexdigest(motor_username.to_s)
         ) &
           ActiveSupport::SecurityUtils.secure_compare(
             ::Digest::SHA256.hexdigest(password),
-            ::Digest::SHA256.hexdigest(ENV['MOTOR_AUTH_PASSWORD'].to_s)
+            ::Digest::SHA256.hexdigest(motor_password.to_s)
           )
       end
     end


### PR DESCRIPTION
Allow credentials to be used alongside environment variables to implement basic authentication.