### PR TITLE
fix: support symbol keys in ActiveRecord reflections

### DIFF
--- a/lib/motor/active_record_utils/active_record_filter.rb
+++ b/lib/motor/active_record_utils/active_record_filter.rb
@@ -97,7 +97,7 @@ module ActiveRecord
                 relations << js
               end
             end
-          elsif reflection = klass._reflections[key.to_s]
+          elsif reflection = klass._reflections[key.to_s] || klass._reflections[key.to_sym]
             if value.is_a?(Hash)
               relations <<
                 if reflection.polymorphic?


### PR DESCRIPTION
This pull request includes a change to the `lib/motor/active_record_utils/active_record_filter.rb` file. The change enhances the `build_filter_joins` method to support both string and symbol keys when accessing reflections.

Enhancements to reflection access:

* [`lib/motor/active_record_utils/active_record_filter.rb`](diffhunk://#diff-dfb8442e581ebe52142857b3a0f4767d809a46c9274a837a6a044794569a4c6aL100-R100): Updated the `build_filter_joins` method to check for reflections using both string and symbol keys, improving flexibility in how reflections are accessed.

---

```
api(dev)> User._reflections
```
The command execution above returns a hash format.
```
=>  {:chats=> #<ActiveRecord::Reflection::HasManyReflection:0x0000ffff7e454f60
...
...
```
Executed in the environment below
```
# rails about
Rails version             7.2.2.1
Ruby version              ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [aarch64-linux]
```