### PR TITLE
Update active_storage_blob_patch.rb to support :key arg

### DIFF
--- a/lib/motor/active_record_utils/active_storage_blob_patch.rb
+++ b/lib/motor/active_record_utils/active_storage_blob_patch.rb
@@ -4,7 +4,7 @@ module Motor
   module ActiveRecordUtils
     module ActiveStorageBlobPatch
       KEYWORD_ARGS =
-        %i[io filename content_type metadata service_name identify record].freeze
+        %i[io filename content_type metadata service_name identify record, key].freeze
 
       def build_after_upload(hash)
         super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)


### PR DESCRIPTION
Currently, this gem prevents the ability to specify keys for attachments. This fixes that