### PR TITLE
Fix "io must be rewindable" error when creating associated record

### DIFF
--- a/lib/motor/active_record_utils/active_storage_blob_patch.rb
+++ b/lib/motor/active_record_utils/active_storage_blob_patch.rb
@@ -4,26 +4,44 @@ module Motor
   module ActiveRecordUtils
     module ActiveStorageBlobPatch
       KEYWORD_ARGS =
-        %i[io filename content_type metadata service_name identify record].freeze
-
-      def build_after_upload(hash)
-        super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)
-      end
+        %i[io filename content_type metadata service_name identify record key].freeze
 
       def build_after_unfurling(hash)
-        super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)
-      end
-
-      def create_after_upload!(hash)
-        super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)
+        super(**normalize_io_args(hash))
       end
 
       def create_after_unfurling!(hash)
-        super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)
+        super(**normalize_io_args(hash))
+      end
+
+      def build_after_upload(hash)
+        super(**normalize_io_args(hash))
+      end
+
+      def create_after_upload!(hash)
+        super(**normalize_io_args(hash))
       end
 
       def create_and_upload!(hash)
-        super(**hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys)
+        super(**normalize_io_args(hash))
+      end
+
+      private
+
+      def normalize_io_args(hash)
+        args = hash.with_indifferent_access.slice(*KEYWORD_ARGS).symbolize_keys
+
+        if args[:io].is_a?(String) && !args[:io].respond_to?(:rewind)
+          args[:io] = StringIO.new(args[:io].b)
+        end
+
+        if args[:content_type].blank? && args[:io].respond_to?(:read)
+          peek = args[:io].read(512)
+          args[:io].rewind
+          args[:content_type] = Marcel::MimeType.for(StringIO.new(peek)) || "application/octet-stream"
+        end
+
+        args
       end
     end
   end

--- a/lib/motor/version.rb
+++ b/lib/motor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motor
-  VERSION = '0.4.37'
+  VERSION = '0.4.38'
 end


### PR DESCRIPTION
This pull request introduces updates to the `ActiveStorageBlobPatch` module to improve how arguments are processed and adds a new utility method for normalization. It also includes a version bump for the `Motor` gem. Below are the key changes:

### Updates to `ActiveStorageBlobPatch`:

* Added a new private method `normalize_io_args` to streamline argument handling. This method ensures that `:io` is converted to a `StringIO` object if necessary and assigns a default `content_type` when missing by inspecting the file's content. (`lib/motor/active_record_utils/active_storage_blob_patch.rb`, [lib/motor/active_record_utils/active_storage_blob_patch.rbL7-R44](diffhunk://#diff-5c1f0a062cd3a5e909402729eb33163cc1ab7855cc8851b78650d15508117331L7-R44))
* Refactored methods (`build_after_upload`, `create_after_upload!`, `build_after_unfurling`, `create_after_unfurling!`, and `create_and_upload!`) to use `normalize_io_args` for consistent argument processing. (`lib/motor/active_record_utils/active_storage_blob_patch.rb`, [lib/motor/active_record_utils/active_storage_blob_patch.rbL7-R44](diffhunk://#diff-5c1f0a062cd3a5e909402729eb33163cc1ab7855cc8851b78650d15508117331L7-R44))
* Extended the `KEYWORD_ARGS` list to include the `key` argument, ensuring compatibility with additional features. (`lib/motor/active_record_utils/active_storage_blob_patch.rb`, [lib/motor/active_record_utils/active_storage_blob_patch.rbL7-R44](diffhunk://#diff-5c1f0a062cd3a5e909402729eb33163cc1ab7855cc8851b78650d15508117331L7-R44))

### Version Update:

* Updated the `Motor` gem version from `0.4.37` to `0.4.38` to reflect the new changes. (`lib/motor/version.rb`, [lib/motor/version.rbL4-R4](diffhunk://#diff-76073c2557c585c90720ca4b4a417f80a7dc4030ebb45680b93ea1c07aef7d49L4-R4))


### To replicate the problem

Upload a file when creating an associated record. RoR 8.0.2 and Ruby 3.4.2

<img width="730" alt="Captura de Tela 2025-06-25 às 19 39 58" src="https://github.com/user-attachments/assets/efd218dd-7f5e-465d-9192-9951d21f9a26" />

