### PR TITLE
fix: record audit logs for nested/association creates

### DIFF
--- a/app/controllers/motor/data_controller.rb
+++ b/app/controllers/motor/data_controller.rb
@@ -28,15 +28,24 @@ module Motor
 
     def create
       if @associated_resource
-        if @resource_class.reflections[params[:association]].through_reflection?
-          @associated_resource.save!
+        reflection = @resource_class.reflections[params[:association]]
 
-          @resource = @associated_resource
-        else
-          @resource.public_send(params[:association].to_sym).create!(resource_params) do |resource|
-            @resource = resource
+        # Build the record through the configured model so that auditing
+        # (enabled on the configured model, not on the raw association class)
+        # is applied to nested/association creates as well.
+        associated_model = Motor::Resources::FetchConfiguredModel.call(
+          reflection.klass,
+          cache_key: Motor::Resource.maximum(:updated_at)
+        )
+
+        @resource =
+          if reflection.through_reflection?
+            @associated_resource.becomes(associated_model)
+          else
+            @resource.public_send(params[:association].to_sym).new(resource_params).becomes(associated_model)
           end
-        end
+
+        @resource.save!
       else
         @resource.save!
       end


### PR DESCRIPTION
# fix: record audit logs for nested/association creates

## TL;DR

When a record is **created** from the Motor Admin UI, whether an audit log is written to `motor_audits` depended on the **shape of the URL**. Top-level creates were audited, but nested creates through a parent association were not.

This PR fixes `DataController#create` so nested/association creates are saved through Motor's configured model path and therefore produce audit logs as well.

| Create path | URL | Audit before | Audit after |
|---|---|:---:|:---:|
| Top-level create | `POST /api/data/employees` | recorded | recorded |
| Nested create through a parent | `POST /api/data/companies/:id/employees` | missing | recorded |

Important scope note: `Motor::Resources::FetchConfiguredModel` can return an anonymous configured subclass even when the associated model does not have an explicit Motor resource config. Because this fix routes nested creates through that configured model path, associated records created via Motor Admin can be audited even if the associated model is only reachable through a parent resource rather than exposed as a top-level Motor resource.

---

## Reproduction

Creating the same `employees` record through two different routes yielded different auditing behavior.

### 1. Top-level create records an audit

```bash
curl 'http://localhost:3000/motor-admin/api/data/employees' \
  -H 'Content-Type: application/json' \
  --data-raw '{"data":{"company_id":1,"name":"Alice","role":"manager","active":true}}'
# => the new record's "audits" tab shows the create audit
```

### 2. Nested create did not record an audit

```bash
curl 'http://localhost:3000/motor-admin/api/data/companies/1/employees' \
  -H 'Content-Type: application/json' \
  --data-raw '{"data":{"name":"Alice","role":"manager","active":true}}'
# => the new record's "audits" tab was empty
```

Confirmed directly in the DB:

```ruby
Motor::Audit.where(auditable_type: "Employee", auditable_id: <toplevel_id>).count # => 1
Motor::Audit.where(auditable_type: "Employee", auditable_id: <nested_id>).count    # => 0
```

---

## Root cause

Motor Admin does not write audit rows directly. Audits are produced by the `audited` gem's model callbacks, and those callbacks are attached to Motor's configured model, which is an anonymous subclass built by `Motor::Resources::FetchConfiguredModel`.

Top-level creates save an instance that goes through this configured model path, so the create callback writes a `Motor::Audit` row.

Nested creates were saving the associated record directly from the parent association path. That meant the saved object did not go through the configured model used by Motor for auditing, so the create callback did not run and no audit row was written.

---

## Fix

For nested creates, the controller now:

1. Reads the association reflection.
2. Resolves the associated model through `Motor::Resources::FetchConfiguredModel`.
3. Builds the record through the association first, so Rails still handles foreign keys, polymorphic attributes, and inverse association setup.
4. Converts the instance with `ActiveRecord#becomes` before saving.

```ruby
reflection = @resource_class.reflections[params[:association]]

associated_model = Motor::Resources::FetchConfiguredModel.call(
  reflection.klass,
  cache_key: Motor::Resource.maximum(:updated_at)
)

@resource =
  if reflection.through_reflection?
    @associated_resource.becomes(associated_model)
  else
    @resource.public_send(params[:association].to_sym).new(resource_params).becomes(associated_model)
  end

@resource.save!
```

This keeps association construction behavior intact while ensuring nested records are saved through the model class that has Motor audit callbacks.

---

## Design rationale

- **Why not call `audited` on the host app's real model?**
  That would also audit operations outside Motor Admin, such as regular API calls or background jobs. This PR keeps the callback on Motor's configured model path instead of mutating the host app's real model class.

- **Why `#becomes`?**
  The record is still assembled through the association, then converted to the configured model class before save. This preserves association wiring while ensuring the configured model's audit callbacks run.

- **Why accept the broader associated-model scope?**
  Nested creates are still Motor Admin operations. Since `FetchConfiguredModel` can build an audited anonymous subclass for associated models, routing nested creates through that path makes auditing consistent for records created from Motor Admin, even when the associated model is primarily reached through a parent resource.

- **Both through and non-through associations.**
  Both nested create paths can save associated records, so both use the same configured-model save flow.

---

## Verification

Verified with `rails runner` in a rolled-back transaction, reproducing a nested create through `Company#employees` with the same save flow as the controller.

Result after the fix:

```text
audit_count=1 action=create auditable_type=Employee
```

---

## Scope

- Only `app/controllers/motor/data_controller.rb` changes.
- Top-level create / update / destroy behavior is unchanged.
- Host app real models are not modified with `audited`.
- Nested associated records created through Motor Admin now go through Motor's configured model path, so audit logging can apply to associated models reachable through parent resources.
